### PR TITLE
Update application of headings and lists

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ We work to bridge the gap between the archive and the classroom. Not all schools
 We create educational resources for K-12 educators, undergraduate, and graduate level instructors, archivists, archival educators, and museum educators.
 
 ## Activities and Products
-* Open-Source Educational Resources
+### Open-Source Educational Resources
 We develop flexible primary source educational resources targeted to levels spanning older elementary to graduate students. These resources are open-source and include curated scans of primary sources from the RAC’s collections. They can be integrated into remote, hybrid, and traditional classroom settings.
 
 ### Educator Workshops

--- a/index.md
+++ b/index.md
@@ -82,6 +82,6 @@ Detailed lesson-by-lesson description of archival education projects.
 Thematic audiovisual documents with scaffolded questions, analysis, and discussion.
 
 ## Additional Resources
-Society of American Archivists’ Primary Source Literacy Guidelines.
+[Society of American Archivists’ Primary Source Literacy Guidelines](https://www2.archivists.org/standards/guidelines-for-primary-source-literacy).
 
 ## Connect with us via our [Teach with Archives](https://resource.rockarch.org/teach-with-archives/) hub.

--- a/index.md
+++ b/index.md
@@ -2,16 +2,16 @@
 layout: docs
 title:  "Archival Education Program Strategy"
 ---
-### Mission
-The RAC’s Archival Education Program’s mission is to demystify the archive and build confidence around the use of primary sources. We want to provide a strong foundation for educators so that they are empowered to help students in the development of their media literacy, research, and critical thinking skills.  
+## Mission
+The RAC’s Archival Education Program’s mission is to demystify the archive and build confidence around the use of primary sources. We want to provide a strong foundation for educators so that they are empowered to help students in the development of their media literacy, research, and critical thinking skills.
 
-### Values
-We work to bridge the gap between the archive and the classroom. Not all schools have the opportunity to connect in person with an archivist, and we believe that by creating open-source materials that are easily accessible, along with opportunities for virtual workshops, we are promoting equity in education. 
+## Values
+We work to bridge the gap between the archive and the classroom. Not all schools have the opportunity to connect in person with an archivist, and we believe that by creating open-source materials that are easily accessible, along with opportunities for virtual workshops, we are promoting equity in education.
 
-### Audience
+## Audience
 We create educational resources for K-12 educators, undergraduate, and graduate level instructors, archivists, archival educators, and museum educators.
 
-### Activities and Products
+## Activities and Products
 • Open-Source Educational Resources
 We develop flexible primary source educational resources targeted to levels spanning older elementary to graduate students. These resources are open-source and include curated scans of primary sources from the RAC’s collections. They can be integrated into remote, hybrid, and traditional classroom settings.
 
@@ -19,15 +19,15 @@ We develop flexible primary source educational resources targeted to levels span
 We connect with cultural organizations and educational institutions to lead workshops that model for faculty and staff the work being done at the RAC. We expand on our belief in open-source materials by sharing frameworks with professionals interested in creating archival education learning opportunities.
 
 •	Archival Educators Roundtable 
-The Archival Education Roundtable was created in 2016 and is a growing community of educators, archivists, and archival education allies who use primary sources for education, outreach, and public engagement. 
+The Archival Education Roundtable was created in 2016 and is a growing community of educators, archivists, and archival education allies who use primary sources for education, outreach, and public engagement.
 
 •	Public Engagement
 The RAC partners with local organizations to create public programming opportunities. We enjoy working with members of the community, learning how their stories connect with and can inform our work, and sharing our resources with lifelong learners.
 
 Partners
-To develop our open-source teaching materials, we collaborate with public schools, colleges, and universities. We partner with educators from a variety of disciplines who are focused on project-based and inquiry-based learning. 
+To develop our open-source teaching materials, we collaborate with public schools, colleges, and universities. We partner with educators from a variety of disciplines who are focused on project-based and inquiry-based learning.
 
-### Pedagogical Goals
+## Pedagogical Goals
 Upper Elementary – Middle School (Grades 3-8)
 Students will:
 •	Learn the difference between primary and secondary sources
@@ -59,14 +59,14 @@ Participants will:
 •	Engage in document analysis
 •	Engage in small group and whole group discussions
 
-### Primary Source Selection
+## Primary Source Selection
 The primary sources selected for archival education address a range of topics and key moments and movements in American and global history. They connect topically to curricula and/or support targeted skill development in inquiry-based and project-based learning.  
 
 We select documents that demonstrate the breadth of our collections, different types of archival formats, and provide opportunities for integrating cultural competency learning. 
 
 The number of documents varies, but we believe in a less-is-more, scaffolded approach to integrating and learning with primary sources. As students and program participants advance in their work with primary sources, they will have the skills to conduct their own further research and be smart consumers and responsible sharers of information.
 
-### Primary Source Educational Resources 
+## Primary Source Educational Resources 
 We create open access models in collaboration with our local lab schools and structure the development of primary source sets, workshops, units, and guides over the course of multiweek, scaffolded remote and in-person visits. 
 
 Primary Source Sets
@@ -81,7 +81,7 @@ Detailed lesson-by-lesson description of archival education projects.
 Audiovisual Media Literacy Guides
 Thematic audiovisual documents with scaffolded questions, analysis, and discussion.
 
-### Additional Resources
+## Additional Resources
 Society of American Archivists’ Primary Source Literacy Guidelines. 
 
 ### Connect with us via our [Teach with Archives] (https://resource.rockarch.org/teach-with-archives/) hub. 

--- a/index.md
+++ b/index.md
@@ -8,6 +8,18 @@ The RAC’s Archival Education Program’s mission is to demystify the archive a
 ## Values
 We work to bridge the gap between the archive and the classroom. Not all schools have the opportunity to connect in person with an archivist, and we believe that by creating open-source materials that are easily accessible, along with opportunities for virtual workshops, we are promoting equity in education.
 
+### Center Equity, Diversity & Accessibility
+We create a diverse and inclusive environment.We help learners of all types to see themselves in the records, to more deeply connect with human experiences in the past. We believe equity means resources for all. Our materials, resources, and learnings are open-source. They are published in venues and formats that our audiences already use. We adopt culturally responsive frameworks in our work.
+
+### Communicate with Transparency and Foster Trust 
+We are transparent about the sources and limitations of our records. Our visual identity is consistent, clear, and cohesive.
+
+### Build from User Needs
+We seek to improve on processes and products to better serve our users. We are open to iteration and change. We seek and value feedback.
+
+### Empower and Collaborate
+We empower ourselves and each other. We are self-starters and create a safe space for our team to grow as individuals and together. We forge meaningful partnerships. We work alongside our colleagues across the RAC and in our professional networks.
+
 ## Audience
 We create educational resources for K-12 educators, undergraduate, and graduate level instructors, archivists, archival educators, and museum educators.
 

--- a/index.md
+++ b/index.md
@@ -15,25 +15,25 @@ We create educational resources for K-12 educators, undergraduate, and graduate 
 * Open-Source Educational Resources
 We develop flexible primary source educational resources targeted to levels spanning older elementary to graduate students. These resources are open-source and include curated scans of primary sources from the RAC’s collections. They can be integrated into remote, hybrid, and traditional classroom settings.
 
-* Educator Workshops
+### Educator Workshops
 We connect with cultural organizations and educational institutions to lead workshops that model for faculty and staff the work being done at the RAC. We expand on our belief in open-source materials by sharing frameworks with professionals interested in creating archival education learning opportunities.
 
-* Archival Educators Roundtable 
+### Archival Educators Roundtable
 The Archival Education Roundtable was created in 2016 and is a growing community of educators, archivists, and archival education allies who use primary sources for education, outreach, and public engagement.
 
-* Public Engagement
+### Public Engagement
 The RAC partners with local organizations to create public programming opportunities. We enjoy working with members of the community, learning how their stories connect with and can inform our work, and sharing our resources with lifelong learners.
 
-Partners
+### Partners
 To develop our open-source teaching materials, we collaborate with public schools, colleges, and universities. We partner with educators from a variety of disciplines who are focused on project-based and inquiry-based learning.
 
 ## Pedagogical Goals
 Upper Elementary – Middle School (Grades 3-8)
 Students will:
 * Learn the difference between primary and secondary sources
-* Be introduced to archives and archival terminology 
+* Be introduced to archives and archival terminology
 * Learn about the work of historians, researchers, and archivists
-* Make personal, classroom, and community connections 
+* Make personal, classroom, and community connections
 * Engage in document analysis
 * Learn about reliable sources
 * Learn why and how to cite sources
@@ -47,8 +47,8 @@ Students will:
 * Engage in document analysis across multiple collections and with a variety of archival formats
 * Engage with primary sources in a variety of ways through close reading, notetaking, and building and articulating an argument
 * Debate using evidence from primary source documents
-* Engage in role-playing from the perspective of the records’ creators 
-* Discuss culturally competent description 
+* Engage in role-playing from the perspective of the records’ creators
+* Discuss culturally competent description
 * Connect sources to context and research in content areas
 * Introduce students to foundation decision-making practices and policy work
 
@@ -60,28 +60,28 @@ Participants will:
 * Engage in small group and whole group discussions
 
 ## Primary Source Selection
-The primary sources selected for archival education address a range of topics and key moments and movements in American and global history. They connect topically to curricula and/or support targeted skill development in inquiry-based and project-based learning.  
+The primary sources selected for archival education address a range of topics and key moments and movements in American and global history. They connect topically to curricula and/or support targeted skill development in inquiry-based and project-based learning.
 
-We select documents that demonstrate the breadth of our collections, different types of archival formats, and provide opportunities for integrating cultural competency learning. 
+We select documents that demonstrate the breadth of our collections, different types of archival formats, and provide opportunities for integrating cultural competency learning.
 
 The number of documents varies, but we believe in a less-is-more, scaffolded approach to integrating and learning with primary sources. As students and program participants advance in their work with primary sources, they will have the skills to conduct their own further research and be smart consumers and responsible sharers of information.
 
-## Primary Source Educational Resources 
-We create open access models in collaboration with our local lab schools and structure the development of primary source sets, workshops, units, and guides over the course of multiweek, scaffolded remote and in-person visits. 
+## Primary Source Educational Resources
+We create open access models in collaboration with our local lab schools and structure the development of primary source sets, workshops, units, and guides over the course of multiweek, scaffolded remote and in-person visits.
 
-Primary Source Sets
+### Primary Source Sets
 Curated set of 4-6 primary source documents and suggested projects related to selected umbrella topics.
 
-Primary Source Workshops
-Thematic selection of primary sources integrated with historical background and exercise procedures. 
+### Primary Source Workshops
+Thematic selection of primary sources integrated with historical background and exercise procedures.
 
-Unit Plans
-Detailed lesson-by-lesson description of archival education projects. 
+### Unit Plans
+Detailed lesson-by-lesson description of archival education projects.
 
-Audiovisual Media Literacy Guides
+### Audiovisual Media Literacy Guides
 Thematic audiovisual documents with scaffolded questions, analysis, and discussion.
 
 ## Additional Resources
-Society of American Archivists’ Primary Source Literacy Guidelines. 
+Society of American Archivists’ Primary Source Literacy Guidelines.
 
 ## Connect with us via our [Teach with Archives](https://resource.rockarch.org/teach-with-archives/) hub.

--- a/index.md
+++ b/index.md
@@ -12,16 +12,16 @@ We work to bridge the gap between the archive and the classroom. Not all schools
 We create educational resources for K-12 educators, undergraduate, and graduate level instructors, archivists, archival educators, and museum educators.
 
 ## Activities and Products
-• Open-Source Educational Resources
+* Open-Source Educational Resources
 We develop flexible primary source educational resources targeted to levels spanning older elementary to graduate students. These resources are open-source and include curated scans of primary sources from the RAC’s collections. They can be integrated into remote, hybrid, and traditional classroom settings.
 
-•	Educator Workshops
+* Educator Workshops
 We connect with cultural organizations and educational institutions to lead workshops that model for faculty and staff the work being done at the RAC. We expand on our belief in open-source materials by sharing frameworks with professionals interested in creating archival education learning opportunities.
 
-•	Archival Educators Roundtable 
+* Archival Educators Roundtable 
 The Archival Education Roundtable was created in 2016 and is a growing community of educators, archivists, and archival education allies who use primary sources for education, outreach, and public engagement.
 
-•	Public Engagement
+* Public Engagement
 The RAC partners with local organizations to create public programming opportunities. We enjoy working with members of the community, learning how their stories connect with and can inform our work, and sharing our resources with lifelong learners.
 
 Partners
@@ -30,34 +30,34 @@ To develop our open-source teaching materials, we collaborate with public school
 ## Pedagogical Goals
 Upper Elementary – Middle School (Grades 3-8)
 Students will:
-•	Learn the difference between primary and secondary sources
-•	Be introduced to archives and archival terminology 
-•	Learn about the work of historians, researchers, and archivists
-•	Make personal, classroom, and community connections 
-•	Engage in document analysis
-•	Learn about reliable sources
-•	Learn why and how to cite sources
-•	Develop research questions
-•	Develop and hone presentation skills
-•	Discuss gaps or “silences” in records
+* Learn the difference between primary and secondary sources
+* Be introduced to archives and archival terminology 
+* Learn about the work of historians, researchers, and archivists
+* Make personal, classroom, and community connections 
+* Engage in document analysis
+* Learn about reliable sources
+* Learn why and how to cite sources
+* Develop research questions
+* Develop and hone presentation skills
+* Discuss gaps or “silences” in records
 
 Intermediate – Advanced (10th grade – University)
 Students will:
-•	Learn about the research process
-•	Engage in document analysis across multiple collections and with a variety of archival formats
-•	Engage with primary sources in a variety of ways through close reading, notetaking, and building and articulating an argument
-•	Debate using evidence from primary source documents
-•	Engage in role-playing from the perspective of the records’ creators 
-•	Discuss culturally competent description 
-•	Connect sources to context and research in content areas
-•	Introduce students to foundation decision-making practices and policy work
+* Learn about the research process
+* Engage in document analysis across multiple collections and with a variety of archival formats
+* Engage with primary sources in a variety of ways through close reading, notetaking, and building and articulating an argument
+* Debate using evidence from primary source documents
+* Engage in role-playing from the perspective of the records’ creators 
+* Discuss culturally competent description 
+* Connect sources to context and research in content areas
+* Introduce students to foundation decision-making practices and policy work
 
 Adult Educational Outreach
 Participants will:
-•	Learn about the RAC/archives
-•	Make connections to their own lives, histories, and communities
-•	Engage in document analysis
-•	Engage in small group and whole group discussions
+* Learn about the RAC/archives
+* Make connections to their own lives, histories, and communities
+* Engage in document analysis
+* Engage in small group and whole group discussions
 
 ## Primary Source Selection
 The primary sources selected for archival education address a range of topics and key moments and movements in American and global history. They connect topically to curricula and/or support targeted skill development in inquiry-based and project-based learning.  

--- a/index.md
+++ b/index.md
@@ -84,5 +84,4 @@ Thematic audiovisual documents with scaffolded questions, analysis, and discussi
 ## Additional Resources
 Society of American Archivists’ Primary Source Literacy Guidelines. 
 
-### Connect with us via our [Teach with Archives] (https://resource.rockarch.org/teach-with-archives/) hub. 
-     
+## Connect with us via our [Teach with Archives](https://resource.rockarch.org/teach-with-archives/) hub.


### PR DESCRIPTION
Updates documentation with some formatting changes:
1. Changes h3 (heading level 3) headings to h2 so that the document doesn't skip heading levels and the table of contents can be built on the site.
2. Uses Markdown notation for bulleted list items (`-` or `*` before the text in Markdown creates bulleted list items)
3. Uses h3 headings instead of paragraphs or single list items at the start of sections

This is now available to preview on the Docs Development site. If everything looks good to you, we can merge it into base at it will appear on [docs.rockarch.org](docs.rockarch.org) and be available publicly!